### PR TITLE
Update JupyterHub API function to make better requests

### DIFF
--- a/jupyterlab_chameleon/artifact.py
+++ b/jupyterlab_chameleon/artifact.py
@@ -381,12 +381,13 @@ class ArtifactAPIClient(LoggingConfigurable):
     def metric(self, uuid: str, slug: str, metric: str):
         call_jupyterhub_api(
             "trovi_metrics",
-            query=[
-                ('origin', get_trovi_token()["access_token"]),
-                ('metric', metric),
-                ('artifact_uuid', uuid),
-                ('artifact_version_slug', slug),
-            ],
+            body={
+                "origin": get_trovi_token()["access_token"],
+                "metric": metric,
+                "artifact_uuid": uuid,
+                "artifact_version_slug": slug,
+            },
+            method="PUT",
         )
 
     def _to_version_request(self, artifact: dict):


### PR DESCRIPTION
The JupyterHub API function is now able to attach a body and/or query to its requests, and doesn't manually encode the query. The artifact metrics caller is updated to take advantage of these features.
