### PR TITLE
Update paramiko

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ COPY scripts/chi-requirements.txt /tmp/chi-requirements.txt
 ARG openstack_release=xena
 RUN curl -L -Sso /upper-constraints.txt "https://raw.githubusercontent.com/openstack/requirements/stable/${openstack_release}/upper-constraints.txt"
 # Unconstrained *client to avoid issues with git install
-RUN python3 -m pip install --no-cache -r /tmp/chi-requirements.txt -c <(grep -v -E 'pyzmq|packaging|blazarclient|heatclient|zunclient' /upper-constraints.txt)
+RUN python3 -m pip install --no-cache -r /tmp/chi-requirements.txt -c <(grep -v -E 'pyzmq|packaging|blazarclient|heatclient|zunclient|PyYAML|paramiko' /upper-constraints.txt)
 RUN rm -f /tmp/chi-requirements.txt /upper-constraints.txt
 
 # FIXME(jason): this should not be necessary, it should automatically be enabled on install.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-DOCKER_REGISTRY = docker.chameleoncloud.org
-IMAGE_NAME = jupyterhub-user
+DOCKER_REGISTRY = ghcr.io/chameleoncloud
+IMAGE_NAME = jupyterlab-chameleon
 DEV_TARGET = dev
 RELEASE_TARGET = release
 RELEASE_PLATFORM = linux/amd64
@@ -23,7 +23,7 @@ watch:
 
 .PHONY: notebook-build
 notebook-build:
-	docker build -t docker.chameleoncloud.org/jupyterhub-user:dev .
+	docker build -t ghcr.io/chameleoncloud/jupyterlab-chameleon:dev .
 
 .PHONY: hub-build-release
 notebook-build-release:
@@ -31,5 +31,5 @@ notebook-build-release:
 
 .PHONY: notebook-publish
 notebook-publish:
-	docker build --no-cache --platform linux/amd64 -t docker.chameleoncloud.org/jupyterhub-user:dev .
-	docker push docker.chameleoncloud.org/jupyterhub-user:dev
+	docker build --no-cache --platform linux/amd64 -t ghcr.io/chameleoncloud/jupyterlab-chameleon:dev .
+	docker push ghcr.io/chameleoncloud/jupyterlab-chameleon:dev

--- a/scripts/chi-requirements.txt
+++ b/scripts/chi-requirements.txt
@@ -16,4 +16,5 @@ git+https://github.com/ChameleonCloud/python-zunclient@chameleoncloud/xena#egg=p
 # ChameleonCloud-provided
 git+https://github.com/ChameleonCloud/jupyterlab-chameleon@main
 python-chi~=0.17.6
-
+PyYAML<5.4
+paramiko>=2.9.0


### PR DESCRIPTION
We were using an old paramiko version due to xena upper constraints, which causes issues with ubuntu 22 key exchange, which defaults to sha2 instead of sha1. This change fixes that, and pins down pyyaml which no longer builds with >=5.4